### PR TITLE
Eliminar hover del componente Contact

### DIFF
--- a/src/components/Contact/Contact.module.css
+++ b/src/components/Contact/Contact.module.css
@@ -114,6 +114,10 @@
         transition: transform 0.3s ease;
     }
 
+    .ContactContainer ul li a:hover {
+        transform: scale(1);
+    }
+
     .ContactContainer ul li:nth-child(3) {
         width: 30px;
         height: 30px;


### PR DESCRIPTION
Se modificó el estilo para los elementos dentro del componente contact par que el hover no genere ningún cambio en los íconos.