### PR TITLE
Eliminar hover del Contact desde teléfono

### DIFF
--- a/src/components/Contact/Contact.module.css
+++ b/src/components/Contact/Contact.module.css
@@ -114,6 +114,10 @@
         transition: transform 0.3s ease;
     }
 
+    .ContactContainer ul li a:hover {
+        transform: scale(1);
+    }
+
     .ContactContainer ul li:nth-child(3) {
         width: 30px;
         height: 30px;

--- a/src/components/Nav/Nav.jsx
+++ b/src/components/Nav/Nav.jsx
@@ -36,7 +36,7 @@ function Nav () {
     }
     function callSelectCurrentSection () {
       if (window.innerWidth > 480) handleScroll(100)
-      else handleScroll(230)
+      else handleScroll(240)
     }
 
     if (window.innerWidth > 480) {


### PR DESCRIPTION
Se modificó el hover del componente Contact para que no genere ninguna modificación sobre los ítems de la lista.

También se modifico la distancia mínima para añadir estilos a los ítems del componente Nav.